### PR TITLE
Enable hardware step counter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,9 @@
         <service
             android:name="org.secuso.privacyfriendlyactivitytracker.services.HardwareStepDetectorService"
             android:stopWithTask="false" />
+        <service
+            android:name="org.secuso.privacyfriendlyactivitytracker.services.HardwareStepCounterService"
+            android:stopWithTask="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/Factory.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/Factory.java
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager;
 
 import org.secuso.privacyfriendlyactivitytracker.services.AbstractStepDetectorService;
 import org.secuso.privacyfriendlyactivitytracker.services.AccelerometerStepDetectorService;
+import org.secuso.privacyfriendlyactivitytracker.services.HardwareStepCounterService;
 import org.secuso.privacyfriendlyactivitytracker.services.HardwareStepDetectorService;
 import org.secuso.privacyfriendlyactivitytracker.utils.AndroidVersionHelper;
 
@@ -11,7 +12,7 @@ import org.secuso.privacyfriendlyactivitytracker.utils.AndroidVersionHelper;
  * Factory class
  *
  * @author Tobias Neidig
- * @version 20160610
+ * @version 20161126
  */
 public class Factory {
 
@@ -23,10 +24,12 @@ public class Factory {
      * @return The class of step detector
      */
     public static Class<? extends AbstractStepDetectorService> getStepDetectorServiceClass(PackageManager pm){
-        if(pm != null && AndroidVersionHelper.supportsStepDetector(pm)) {
-            return HardwareStepDetectorService.class;
-        }else{
-            return AccelerometerStepDetectorService.class;
+        if(pm != null) {
+            if (AndroidVersionHelper.supportsStepCounter(pm))
+                return HardwareStepCounterService.class;
+            if (AndroidVersionHelper.supportsStepDetector(pm))
+                return HardwareStepDetectorService.class;
         }
+        return AccelerometerStepDetectorService.class;
     }
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/services/HardwareStepCounterService.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/services/HardwareStepCounterService.java
@@ -1,0 +1,75 @@
+package org.secuso.privacyfriendlyactivitytracker.services;
+
+import android.annotation.SuppressLint;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.util.Log;
+
+import org.secuso.privacyfriendlyactivitytracker.utils.AndroidVersionHelper;
+
+/**
+ * Uses the hardware step counter sensor to detect steps.
+ * Publishes the detected steps to any subscriber.
+ *
+ * @author Jens Kehne
+ * @version 20161126
+ */
+
+public class HardwareStepCounterService extends AbstractStepDetectorService {
+
+    private static final String LOG_TAG = HardwareStepCounterService.class.getName();
+
+    /**
+     * Number of steps which the user went today
+     * This is used when step counter is used.
+     */
+    private float mStepOffset = -1;
+
+    /**
+     * Creates an HardwareStepDetectorService.
+     */
+    public HardwareStepCounterService(){
+        this("");
+        // required empty constructor
+    }
+
+    /**
+     * Creates an HardwareStepDetectorService.
+     *
+     * @param name Name for the worker thread, use it for debugging purposes
+     */
+    public HardwareStepCounterService(String name) {
+        super(name);
+        Log.i(LOG_TAG, "Created step counter service");
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (event.sensor.getType() != Sensor.TYPE_STEP_COUNTER)
+            return;
+
+        if (this.mStepOffset < 0) {
+            this.mStepOffset = event.values[0];
+        }
+
+        if (this.mStepOffset > event.values[0]) {
+            // this should never happen?
+            return;
+        }
+
+        // publish difference between last known step count and the current ones.
+        this.onStepDetected((int) (event.values[0] - mStepOffset));
+        // Set offset to current value so we know it at next event
+        mStepOffset = event.values[0];
+    }
+
+    @SuppressLint("InlinedApi")
+    @Override
+    public int getSensorType() {
+        if (AndroidVersionHelper.supportsStepCounter(getPackageManager())) {
+            return Sensor.TYPE_STEP_COUNTER;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/services/HardwareStepDetectorService.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/services/HardwareStepDetectorService.java
@@ -3,22 +3,20 @@ package org.secuso.privacyfriendlyactivitytracker.services;
 import android.annotation.SuppressLint;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
+import android.util.Log;
 
 import org.secuso.privacyfriendlyactivitytracker.utils.AndroidVersionHelper;
 
 /**
- * Uses the hardware step counter sensor to detect steps.
+ * Uses the hardware step detector sensor to detect steps.
  * Publishes the detected steps to any subscriber.
  *
  * @author Tobias Neidig
- * @version 20160522
+ * @version 20161126
  */
 public class HardwareStepDetectorService extends AbstractStepDetectorService {
-    /**
-     * Number of steps which the user went today
-     * This is used when step counter is used.
-     */
-    private float mStepOffset = -1;
+
+    private static final String LOG_TAG = HardwareStepDetectorService.class.getName();
 
     /**
      * Creates an HardwareStepDetectorService.
@@ -35,28 +33,15 @@ public class HardwareStepDetectorService extends AbstractStepDetectorService {
      */
     public HardwareStepDetectorService(String name) {
         super(name);
+        Log.i(LOG_TAG, "Created step counter service");
     }
 
     @Override
     public void onSensorChanged(SensorEvent event) {
-        switch (event.sensor.getType()) {
-            case Sensor.TYPE_STEP_DETECTOR:
-                this.onStepDetected(1);
-                break;
-            case Sensor.TYPE_STEP_COUNTER:
-                if (this.mStepOffset < 0) {
-                    this.mStepOffset = event.values[0];
-                }
-                if (this.mStepOffset > event.values[0]) {
-                    // this should never happen?
-                    return;
-                }
-                // publish difference between last known step count and the current ones.
-                this.onStepDetected((int) (event.values[0] - mStepOffset));
-                // Set offset to current value so we know it at next event
-                mStepOffset = event.values[0];
-                break;
-        }
+        if (event.sensor.getType() != Sensor.TYPE_STEP_DETECTOR)
+            return;
+
+        this.onStepDetected(1);
     }
 
     @SuppressLint("InlinedApi")

--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/utils/AndroidVersionHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/utils/AndroidVersionHelper.java
@@ -6,7 +6,7 @@ import android.os.Build;
 /**
  *
  * @author Tobias Neidig
- * @version 20160610
+ * @version 20161126
  */
 public class AndroidVersionHelper {
     /**
@@ -19,10 +19,19 @@ public class AndroidVersionHelper {
         // https://developer.android.com/about/versions/android-4.4.html
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
                 // In addition to the system version
-                // the hardware step detection is not supported on every device
+                // the hardware step counter is not supported on every device
                 // let's check the device's ability.
-                && pm.hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER)
                 && pm.hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_DETECTOR);
 
+    }
+
+    public static boolean supportsStepCounter(PackageManager pm) {
+        // (Hardware) step detection was introduced in KitKat (4.4 / API 19)
+        // https://developer.android.com/about/versions/android-4.4.html
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+                // In addition to the system version
+                // the hardware step detection is not supported on every device
+                // let's check the device's ability.
+                && pm.hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER);
     }
 }


### PR DESCRIPTION
I have implemented a service for the hardware step counter as suggested in #5. This service is used by default if the hardware step counter is available. if not, the step detector is used as a fallback.
I have been using this patch for a few days now, and haven't run into any problems so far.
Note that I did not add a setting to let the user select which sensor to use. Honestly, I don't think such a setting makes sense since I don't see any advantage of the step detector over the step counter. 