### PR TITLE
fix: incorrect date and timey in CSV export

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/persistence/StepCountDbHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/persistence/StepCountDbHelper.java
@@ -256,7 +256,7 @@ public class StepCountDbHelper  extends SQLiteOpenHelper {
         public static final String TABLE_NAME = StepCountDbHelper.TABLE_NAME;
         public static final String KEY_STEP_COUNT = StepCountDbHelper.KEY_STEP_COUNT;
         public static final String KEY_WALKING_MODE = StepCountDbHelper.KEY_WALKING_MODE;
-        public static final String KEY_TIMESTAMP = KEY_WALKING_MODE;
+        public static final String KEY_TIMESTAMP = StepCountDbHelper.KEY_TIMESTAMP;
     }
 
 

--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/persistence/StepCountPersistenceHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/persistence/StepCountPersistenceHelper.java
@@ -205,7 +205,7 @@ public class StepCountPersistenceHelper {
         }
         Cursor c = getDB(context).query(StepCountDbHelper.StepCountEntry.TABLE_NAME,
                 new String[]{StepCountDbHelper.StepCountEntry.KEY_STEP_COUNT, StepCountDbHelper.StepCountEntry.KEY_TIMESTAMP, StepCountDbHelper.StepCountEntry.KEY_WALKING_MODE},
-                "", new String[]{}, null, null, null);
+                "", new String[]{}, null, null, StepCountDbHelper.StepCountEntry.KEY_TIMESTAMP + " ASC");
         List<StepCount> steps = new ArrayList<>();
         long start = 0;
         int sum = 0;


### PR DESCRIPTION
Hi,
This is patch for #80 

Wrong declaration StepCountEntry.KEY_TIMESTAMP caused loading wrong column
walking mode instead of timestamp from databases.
Also loaded data should be sorted by timestamp.
