### PR TITLE
Create parent dirs for CSV export if they do not exist

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/activities/PreferencesActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyactivitytracker/activities/PreferencesActivity.java
@@ -452,6 +452,9 @@ public class PreferencesActivity extends AppCompatPreferenceActivity {
             try {
                 if (csvFile.exists())
                     csvFile.delete();
+                File parentDir = new File(csvFile.getParent());
+                if (!parentDir.exists())
+                    parentDir.mkdirs();
                 csvFile.createNewFile();
                 //Generate the file
                 PrintWriter csvWriter = new PrintWriter(csvFile);


### PR DESCRIPTION
This should fully resolve #82 and be part of the bug fix release.

(Discovered this issue with first instrumented tests.)
