### PR TITLE
#74

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,10 +85,10 @@
         <activity
             android:name="org.secuso.privacyfriendlyactivitytracker.activities.TrainingActivity"
             android:label="@string/activity_title_training"
-            android:parentActivityName="org.secuso.privacyfriendlyactivitytracker.activities.TrainingOverviewActivity">
+            android:parentActivityName="org.secuso.privacyfriendlyactivitytracker.activities.MainActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.secuso.privacyfriendlyactivitytracker.activities.TrainingOverviewActivity" />
+                android:value="org.secuso.privacyfriendlyactivitytracker.activities.MainActivity" />
         </activity>
         <activity
             android:name="org.secuso.privacyfriendlyactivitytracker.activities.TrainingOverviewActivity"


### PR DESCRIPTION
Privacy

https://github.com/SecUSo/privacy-friendly-pedometer/issues/74  

# Current behaviour on TrainingActivity

> TrainingActivity = in-progress training

## The action bar 'Up' on TrainingActivity



- Navigates to the TrainingOverviewActivity
- TrainingOverviewActivity immediately reports "Found active training session"
- TrainingOverviewActivity immediately redirects to the active training session

## The Android back button on TrainingActivity



- Navigates to the TrainingOverviewActivity
- Does not lead to a redirect back to TrainingActivity

## The Plus Button on TrainingOverviewActivity

- Start a new training session if none exists
- If there is a current Training session, it will navigate to it, which was already running the background

# Solution

## Main Solution:

- Only allow access to TrainingOverviewActivity if there is no current running training
- Back button on TrainingActivity leads to the MainActivity

